### PR TITLE
Add marigold node

### DIFF
--- a/img_proc/image.py
+++ b/img_proc/image.py
@@ -53,13 +53,13 @@ def apply_orientation(oiio_image, orientation, reverse: bool = False):
     return oiio_image
 
 
-def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = True):
+def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = True, clipLow: float = 0.0, clipHigh: float = 1.0, colorSpace = avimg.EImageColorSpace_SRGB):
     oiio_input = oiio.ImageInput.open(imagePath)
     oiio_spec = oiio_input.spec()
     oiio_input.close()
 
     av_image = avimg.Image_RGBfColor()
-    avOptRead = avimg.ImageReadOptions(avimg.EImageColorSpace_SRGB)
+    avOptRead = avimg.ImageReadOptions(colorSpace)
     avimg.readImage(imagePath, av_image, avOptRead)
     oiio_image = av_image.getNumpyArray()
 
@@ -79,8 +79,8 @@ def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = T
         oiio_image = oiio_image_buf.get_pixels(format=oiio.FLOAT)
 
     oiio_image_buf = oiio.ImageBuf(oiio_image)
-    oiio.ImageBufAlgo.max(oiio_image_buf, oiio_image_buf, 0.0)
-    oiio.ImageBufAlgo.min(oiio_image_buf, oiio_image_buf, 1.0)
+    oiio.ImageBufAlgo.max(oiio_image_buf, oiio_image_buf, clipLow)
+    oiio.ImageBufAlgo.min(oiio_image_buf, oiio_image_buf, clipHigh)
     oiio_image = oiio_image_buf.get_pixels(format=oiio.FLOAT)
 
     return (oiio_image, h, w, pixelAspectRatio, orientation)

--- a/marigold_utils/loadPipe.py
+++ b/marigold_utils/loadPipe.py
@@ -1,0 +1,34 @@
+import os
+
+def loadPipe(type: str = "depth"):
+    import torch
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    variant = None #"fp16"
+    dtype = torch.float32 #torch.float16
+    pipeType = type.lower()
+
+    if pipeType == "depth":
+        from marigold import MarigoldDepthPipeline
+        print("Loading Marigold depth model...")
+        checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + "/marigold-depth-v1-1/"
+        pipe: MarigoldDepthPipeline = MarigoldDepthPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype)
+    elif pipeType == "normals":
+        from marigold import MarigoldNormalsPipeline
+        print("Loading Marigold normals model...")
+        checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + "/marigold-normals-v1-1/"
+        pipe: MarigoldNormalsPipeline = MarigoldNormalsPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype)
+    elif pipeType in ["appearance", "lighting"]:
+        from marigold import MarigoldIIDPipeline
+        print(f"Loading Marigold {pipeType} model...")
+        checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + f"/marigold-iid-{pipeType}-v1-1/"
+        pipe: MarigoldIIDPipeline = MarigoldIIDPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype)
+    else:
+        return None
+
+    # try:
+    #     pipe.enable_xformers_memory_efficient_attention()
+    # except ImportError:
+    #     pass  # run without xformers
+
+    pipe = pipe.to(device)
+    return pipe

--- a/marigold_utils/loadPipe.py
+++ b/marigold_utils/loadPipe.py
@@ -9,19 +9,22 @@ def loadPipe(type: str = "depth"):
 
     if pipeType == "depth":
         from marigold import MarigoldDepthPipeline
-        print("Loading Marigold depth model...")
         checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + "/marigold-depth-v1-1/"
-        pipe: MarigoldDepthPipeline = MarigoldDepthPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype)
+        pipe: MarigoldDepthPipeline = MarigoldDepthPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype).to(device)
+    elif pipeType == "depthcompletion":
+        from marigold_utils.marigold_dc import MarigoldDepthCompletionPipeline
+        from diffusers import DDIMScheduler
+        checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + "/marigold-depth-v1-1/"
+        pipe: MarigoldDepthCompletionPipeline = MarigoldDepthCompletionPipeline.from_pretrained(checkpoint_path, prediction_type="depth").to(device)
+        pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config, timestep_spacing="trailing")
     elif pipeType == "normals":
         from marigold import MarigoldNormalsPipeline
-        print("Loading Marigold normals model...")
         checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + "/marigold-normals-v1-1/"
-        pipe: MarigoldNormalsPipeline = MarigoldNormalsPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype)
+        pipe: MarigoldNormalsPipeline = MarigoldNormalsPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype).to(device)
     elif pipeType in ["appearance", "lighting"]:
         from marigold import MarigoldIIDPipeline
-        print(f"Loading Marigold {pipeType} model...")
         checkpoint_path = os.getenv('MARIGOLD_MODELS_PATH') + f"/marigold-iid-{pipeType}-v1-1/"
-        pipe: MarigoldIIDPipeline = MarigoldIIDPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype)
+        pipe: MarigoldIIDPipeline = MarigoldIIDPipeline.from_pretrained(checkpoint_path, variant=variant, torch_dtype=dtype).to(device)
     else:
         return None
 
@@ -30,5 +33,4 @@ def loadPipe(type: str = "depth"):
     # except ImportError:
     #     pass  # run without xformers
 
-    pipe = pipe.to(device)
     return pipe

--- a/marigold_utils/marigold_dc.py
+++ b/marigold_utils/marigold_dc.py
@@ -1,0 +1,201 @@
+import logging
+import os
+import warnings
+import argparse
+
+import diffusers
+import numpy as np
+import torch
+from diffusers import MarigoldDepthPipeline
+from PIL import Image
+from img_proc import image
+from pathlib import Path
+from pyalicevision import image as avimg
+
+
+warnings.simplefilter(action="ignore", category=FutureWarning)
+diffusers.utils.logging.disable_progress_bar()
+
+class MarigoldDepthCompletionPipeline(MarigoldDepthPipeline):
+    """
+    Pipeline for Marigold Depth Completion.
+    Extends the MarigoldDepthPipeline to include depth completion functionality.
+    """
+    def __call__(
+        self, image: Image.Image, sparse_depth: np.ndarray,
+        num_inference_steps: int = 50, processing_resolution: int = 768, seed: int = 2024
+    ) -> np.ndarray:
+        
+        """
+        Args:
+            image (PIL.Image.Image): Input image of shape [H, W] with 3 channels.
+            sparse_depth (np.ndarray): Sparse depth guidance of shape [H, W].
+            num_inference_steps (int, optional): Number of denoising steps. Defaults to 50.
+            processing_resolution (int, optional): Resolution for processing. Defaults to 768.
+            seed (int, optional): Random seed. Defaults to 2024.
+
+        Returns:
+            np.ndarray: Dense depth prediction of shape [H, W].
+
+        """
+        # Resolving variables
+        device = self._execution_device
+        generator = torch.Generator(device=device).manual_seed(seed)
+
+        # Check inputs.
+        if num_inference_steps is None:
+            raise ValueError("Invalid num_inference_steps")
+        if type(sparse_depth) is not np.ndarray or sparse_depth.ndim != 2:
+            raise ValueError("Sparse depth should be a 2D numpy ndarray with zeros at missing positions")
+
+        # Prepare empty text conditioning
+        with torch.no_grad():
+            if self.empty_text_embedding is None:
+                text_inputs = self.tokenizer("", padding="do_not_pad", 
+                    max_length=self.tokenizer.model_max_length, truncation=True, return_tensors="pt")
+                text_input_ids = text_inputs.input_ids.to(device)
+                self.empty_text_embedding = self.text_encoder(text_input_ids)[0]  # [1,2,1024]
+
+        # Preprocess input images
+        image, padding, original_resolution = self.image_processor.preprocess(
+            image, processing_resolution=processing_resolution, device=device, dtype=self.dtype
+        )  # [N,3,PPH,PPW]
+
+        # Check sparse depth dimensions
+        if sparse_depth.shape != original_resolution:
+            raise ValueError(
+                f"Sparse depth dimensions ({sparse_depth.shape}) must match that of the image ({image.shape[-2:]})"
+            )
+        
+        # Encode input image into latent space
+        with torch.no_grad():
+            image_latent, pred_latent = self.prepare_latents(image, None, generator, 1, 1)  # [N*E,4,h,w], [N*E,4,h,w]
+        del image
+
+        # Preprocess sparse depth
+        sparse_depth = torch.from_numpy(sparse_depth)[None, None].float().to(device)
+        sparse_mask = sparse_depth > 0
+        logging.info(f"Using {sparse_mask.int().sum().item()} guidance points")
+
+        # Set up optimization targets and compute the range and lower bound of the sparse depth
+        scale, shift = torch.nn.Parameter(torch.ones(1, device=device)), torch.nn.Parameter(torch.ones(1, device=device))
+        pred_latent = torch.nn.Parameter(pred_latent)
+        sparse_range = (sparse_depth[sparse_mask].max() - sparse_depth[sparse_mask].min()).item() # (cmax − cmin)
+        sparse_lower = (sparse_depth[sparse_mask].min()).item() # cmin
+        
+        # Set up optimizer
+        optimizer = torch.optim.Adam([ {"params": [scale, shift], "lr": 0.005},
+                                       {"params": [pred_latent] , "lr": 0.05 }])
+
+        def affine_to_metric(depth: torch.Tensor) -> torch.Tensor:
+            # Convert affine invariant depth predictions to metric depth predictions using the parametrized scale and shift. See Equation 2 of the paper.
+            return (scale**2) * sparse_range * depth + (shift**2) * sparse_lower
+
+        def latent_to_metric(latent: torch.Tensor) -> torch.Tensor:
+            # Decode latent to affine invariant depth predictions and subsequently to metric depth predictions.
+            affine_invariant_prediction = self.decode_prediction(latent)  # [E,1,PPH,PPW]
+            prediction = affine_to_metric(affine_invariant_prediction)
+            prediction = self.image_processor.unpad_image(prediction, padding)  # [E,1,PH,PW]
+            prediction = self.image_processor.resize_antialias(
+                prediction, original_resolution, "bilinear", is_aa=False
+            )  # [1,1,H,W]
+            return prediction
+
+        def loss_l1l2(input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+            # Compute L1 and L2 loss between input and target.
+            out_l1 = torch.nn.functional.l1_loss(input, target)
+            out_l2 = torch.nn.functional.mse_loss(input, target)
+            out = out_l1 + out_l2
+            return out
+
+        # Denoising loop
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        for _, t in enumerate(
+            #self.progress_bar(self.scheduler.timesteps, desc=f"Marigold-DC steps ({str(device)})...")
+            self.scheduler.timesteps
+        ):
+            optimizer.zero_grad()
+
+            # Forward pass through the U-Net
+            batch_latent = torch.cat([image_latent, pred_latent], dim=1)  # [1,8,h,w]
+            noise = self.unet(
+                batch_latent, t, encoder_hidden_states=self.empty_text_embedding, return_dict=False
+            )[0]  # [1,4,h,w]
+
+            # Compute pred_epsilon to later rescale the depth latent gradient
+            with torch.no_grad():
+                alpha_prod_t = self.scheduler.alphas_cumprod[t]
+                beta_prod_t = 1 - alpha_prod_t
+                pred_epsilon = (alpha_prod_t**0.5) * noise + (beta_prod_t**0.5) * pred_latent
+
+            step_output = self.scheduler.step(noise, t, pred_latent, generator=generator)
+
+            # Preview the final output depth with Tweedie's formula (See Equation 1 of the paper)
+            pred_original_sample = step_output.pred_original_sample
+
+            # Decode to metric space, compute loss with guidance and backpropagate
+            current_metric_estimate = latent_to_metric(pred_original_sample)
+            loss = loss_l1l2(current_metric_estimate[sparse_mask], sparse_depth[sparse_mask])
+            loss.backward()
+
+            # Scale gradients up
+            with torch.no_grad():
+                pred_epsilon_norm = torch.linalg.norm(pred_epsilon).item()
+                depth_latent_grad_norm = torch.linalg.norm(pred_latent.grad).item()
+                scaling_factor = pred_epsilon_norm / max(depth_latent_grad_norm, 1e-8)
+                pred_latent.grad *= scaling_factor
+
+            # Execute the update step through guidance backprop
+            optimizer.step()
+
+            # Execute update of the latent with regular denoising diffusion step
+            with torch.no_grad():
+                pred_latent.data = self.scheduler.step(noise, t, pred_latent, generator=generator).prev_sample
+
+            del pred_original_sample, current_metric_estimate, step_output, pred_epsilon, noise
+            torch.cuda.empty_cache()
+
+        del image_latent
+
+        # Decode predictions from latent into pixel space
+        with torch.no_grad():
+            prediction = latent_to_metric(pred_latent.detach())
+
+        # return Numpy array
+        prediction = self.image_processor.pt_to_numpy(prediction)  # [N,H,W,1]
+        self.maybe_free_model_hooks()
+
+        return prediction.squeeze()
+
+
+def search_partial_depth(depth_dir, depth_ext, img_path, img_meta):
+    # Search for an existing partial depth
+    input_depth = None
+    if Path(depth_dir).is_dir():
+        input_depth_map_names = []
+        input_depth_map_names.append("depth_" + str(img_path[0].stem) + depth_ext)
+        input_depth_map_names.append(str(img_path[0].stem) + "_depth" + depth_ext)
+        input_depth_map_names.append("depth_" + img_path[1] + depth_ext)
+        input_depth_map_names.append(img_path[1] + "_depth" + depth_ext)
+        input_depth_map_names.append("depthMap_" + str(img_path[0].stem) + depth_ext)
+        input_depth_map_names.append(str(img_path[0].stem) + "_depthMap" + depth_ext)
+        input_depth_map_names.append("depthMap_" + img_path[1] + depth_ext)
+        input_depth_map_names.append(img_path[1] + "_depthMap" + depth_ext)
+        input_depth_map_file_path = None
+        for name in input_depth_map_names:
+            file_path = os.path.join(depth_dir, name)
+            if os.path.exists(file_path):
+                input_depth_map_file_path = file_path
+                break
+        if input_depth_map_file_path is not None:
+            # Load partial depth map
+            print(f"Found partial depth map {input_depth_map_file_path}")
+            if depth_ext == '.npy':
+                input_depth = np.load(input_depth_map_file_path)
+            else: # '.exr'
+                input_depth, h_depth, w_depth, par_depth, orientation_depth = image.loadImage(input_depth_map_file_path, applyPAR = True, clipHigh = 1000.0, colorSpace = avimg.EImageColorSpace_NO_CONVERSION)
+                if (h_depth, w_depth, par_depth, orientation_depth) == img_meta:
+                    input_depth = input_depth[:,:,0]
+
+    return (input_depth, input_depth_map_file_path)
+

--- a/meshroom/imageIntrinsicsEstimation/Marigold.py
+++ b/meshroom/imageIntrinsicsEstimation/Marigold.py
@@ -1,0 +1,520 @@
+__version__ = "1.0"
+
+from re import M
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+class MarigoldNodeSize(desc.MultiDynamicNodeSize):
+    def computeSize(self, node):
+        from pathlib import Path
+        import itertools
+
+        input_path_param = node.attribute(self._params[0])
+        extension_param = node.attribute(self._params[1])
+
+        input_path = input_path_param.value
+        extension = extension_param.value
+        include_suffixes = [extension.lower(), extension.upper()]
+
+        size = 1
+        if Path(input_path).is_dir():
+            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            size = len(image_paths)
+        elif node.attribute(self._params[0]).isLink:
+            size = node.attribute(self._params[0]).getLinkParam().node.size
+        
+        return size
+
+
+class MarigoldBlockSize(desc.Parallelization):
+    def getSizes(self, node):
+        import math
+
+        size = node.size
+        if node.attribute('blockSize').value:
+            nbBlocks = int(math.ceil(float(size) / float(node.attribute('blockSize').value)))
+            return node.attribute('blockSize').value, size, nbBlocks
+        else:
+            return size, size, 1
+
+
+class Marigold(desc.Node):
+    category = "Image Intrinsics"
+    documentation = """This node computes depth, normal, fov and mesh from a monocular image using the Marigold deep model."""
+    
+    gpu = desc.Level.INTENSIVE
+
+    size = MarigoldNodeSize(['inputImages', 'inputExtension'])
+    parallelization = MarigoldBlockSize()
+
+    inputs = [
+        desc.File(
+            name="inputImages",
+            label="Input Images",
+            description="Input images to process. Folder path or sfmData filepath",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="inputExtension",
+            label="Input Extension",
+            description="Extension of the input images. This will be used to determine which images are to be used if \n"
+                        "a directory is provided as the input.",
+            values=["jpg", "jpeg", "png", "exr"],
+            value="exr",
+            exclusive=True,
+        ),
+        desc.ChoiceParam(
+            name="outputFormat",
+            label="Output Extension",
+            description="Output extension for depth map, normal map, albedo, shading and residual.",
+            values=[".exr", ".npy"],
+            value=".exr",
+            exclusive=True,
+        ),
+        desc.BoolParam(
+            name="computeDepth",
+            label="Compute Depth Map",
+            description="If this option is enabled, a depth map is computed.",
+            value=True,
+        ),
+        desc.BoolParam(
+            name="computeNormals",
+            label="Compute Normal Map",
+            description="If this option is enabled, a normal map is computed.",
+            value=True,
+        ),
+        desc.BoolParam(
+            name="computeLighting",
+            label="Compute Lighting",
+            description="If this option is enabled, albedo, shading and residual images are computed.",
+            value=True,
+        ),
+        desc.BoolParam(
+            name="computeAppearance",
+            label="Compute Appearance",
+            description="If this option is enabled, albedo and material images are computed.",
+            value=True,
+        ),
+        desc.IntParam(
+            name="denoisingStep",
+            label="Denoising Steps",
+            value=0,
+            description="Number of denoising steps in diffusion. Set to 0 to use the predifined value for each feature.",
+            range=(0, 50, 1),
+        ),
+        desc.IntParam(
+            name="ensembleSize",
+            label="Ensemble Size",
+            value=0,
+            description="Number of averaged predictions to get the final result. Set to 0 to use the predifined value for each feature.",
+            range=(0, 50, 1),
+        ),
+        desc.IntParam(
+            name="seedGenerator",
+            label="Seed Generator",
+            value=-1,
+            description="Reproducibility seed. Set to negative value for randomized inference.",
+            #range=(0, 50, 1),
+        ),
+        desc.IntParam(
+            name="processingResolution",
+            label="Processing Resolution",
+            value=-1,
+            description="Resolution to which the input is resized before performing estimation. `0` uses the original input, '-1' resolves the best default from the model checkpoint.",
+            range=(-1, 8192, 1),
+        ),
+        desc.BoolParam(
+            name="outputProcessingResolution",
+            label="Output Processing Resolution",
+            description="Setting this flag will output the result at the effective value of `processing_res`, otherwise the output will be resized to the input resolution.",
+            value=False,
+        ),
+        desc.ChoiceParam(
+            name="resamplingMethod",
+            label="Resampling Method",
+            description="Resampling method used to resize images and predictions.",
+            values=["bilinear", "bicubic", "nearest"],
+            value="bilinear",
+            exclusive=True,
+        ),
+        desc.BoolParam(
+            name="saveVisuImages",
+            label="Save images for visualization",
+            description="Save additional png images for depth and normal maps.",
+            value=False,
+        ),
+        desc.IntParam(
+            name="blockSize",
+            label="Block Size",
+            value=50,
+            description="Sets the number of images to process in one chunk. If set to 0, all images are processed at once.",
+            range=(0, 1000, 1),
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug, trace).",
+            values=VERBOSE_LEVEL,
+            value="info",
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name='output',
+            label='Output Folder',
+            description="Output folder containing the computed images.",
+            value="{nodeCacheFolder}",
+        ),
+        desc.File(
+            name="NormalMap",
+            label="Normal Map",
+            description="Output colored normal map",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/normals_vis_<FILESTEM>.png",
+            group="",
+            enabled=lambda node: node.computeNormals.value and node.saveVisuImages.value
+        ),
+        desc.File(
+            name="DepthMap",
+            label="Depth Map",
+            description="Output colored depth map",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/depth_vis_<FILESTEM>.png",
+            group="",
+            enabled=lambda node: node.computeDepth.value and node.saveVisuImages.value
+        ),
+        desc.File(
+            name="AlbedoFromAppearance",
+            label="Albedo From Appearance",
+            description="Output albedo extrated from appearance model",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/albedo_appearance_<FILESTEM>.exr",
+            group="",
+            enabled=lambda node: node.computeAppearance.value and node.outputFormat.value == ".exr"
+        ),
+        desc.File(
+            name="AlbedoFromLighting",
+            label="Albedo From Lighting",
+            description="Output albedo extrated from lighting model",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/albedo_lighting_<FILESTEM>.exr",
+            group="",
+            enabled=lambda node: node.computeLighting.value and node.outputFormat.value == ".exr"
+        ),
+        desc.File(
+            name="MaterialFromAppearance",
+            label="Material From Appearance",
+            description="Output material extrated from appearance model",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/material_appearance_<FILESTEM>.exr",
+            group="",
+            enabled=lambda node: node.computeAppearance.value and node.outputFormat.value == ".exr"
+        ),
+        desc.File(
+            name="ShadingFromLighting",
+            label="Shading From Lighting",
+            description="Output shading extrated from lighting model",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/shading_lighting_<FILESTEM>.exr",
+            group="",
+            enabled=lambda node: node.computeLighting.value and node.outputFormat.value == ".exr"
+        ),
+        desc.File(
+            name="ResidualFromLighting",
+            label="Residual From Lighting",
+            description="Output residual extrated from lighting model",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/residual_lighting_<FILESTEM>.exr",
+            group="",
+            enabled=lambda node: node.computeLighting.value and node.outputFormat.value == ".exr"
+        ),
+    ]
+
+    def preprocess(self, node):
+        extension = node.inputExtension.value
+        input_path = node.inputImages.value
+
+        image_paths = get_image_paths_list(input_path, extension)
+
+        if len(image_paths) == 0:
+            raise FileNotFoundError(f'No image files found in {input_path}')
+
+        self.image_paths = image_paths
+
+    def processChunk(self, chunk):
+        import torch
+        from img_proc import image
+        from marigold_utils import loadPipe
+        import numpy as np
+        from pathlib import Path
+        from PIL import Image
+
+        try:
+            chunk.logManager.start(chunk.node.verboseLevel.value)
+            if not chunk.node.inputImages.value:
+                chunk.logger.warning('No input folder given.')
+
+            chunk_image_paths = self.image_paths[chunk.range.start:chunk.range.end]
+
+            # computation
+            chunk.logger.info(f'Starting computation on chunk {chunk.range.iteration + 1}/{chunk.range.fullSize // chunk.range.blockSize + int(chunk.range.fullSize != chunk.range.blockSize)}...')
+
+            output_dir_path = Path(chunk.node.output.value)
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+            processing_res = None
+            if chunk.node.processingResolution.value >= 0:
+                processing_res = chunk.node.processingResolution.value
+            match_input_res = not chunk.node.outputProcessingResolution.value
+            resample_method = chunk.node.resamplingMethod.value
+
+            chunk.logger.info('Common processing parameters:')
+            chunk.logger.info(f'    Match Input Resolution = {match_input_res}')
+            chunk.logger.info(f'    Resampling Method = {resample_method}')
+
+            if chunk.node.computeDepth.value:
+                from marigold import MarigoldDepthPipeline, MarigoldDepthOutput
+
+                pipe: MarigoldDepthPipeline = loadPipe.loadPipe("depth")
+                denoise_steps = chunk.node.denoisingStep.value if chunk.node.denoisingStep.value > 0 else 1;
+                ensemble_size = chunk.node.ensembleSize.value if chunk.node.ensembleSize.value > 0 else 10;
+
+                chunk.logger.info('Depth processing parameters:')
+                chunk.logger.info(f'    Processing Resolution = {processing_res or pipe.default_processing_resolution}')
+                chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
+                chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
+
+                for idx, path in enumerate(chunk_image_paths):
+                    with torch.no_grad():
+                        input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), applyPAR = True)
+                        input_image = Image.fromarray((255.0*input_image).astype(np.uint8))
+
+                        # Random number generator
+                        if chunk.node.seedGenerator.value < 0:
+                            generator = None
+                        else:
+                            generator = torch.Generator(device=device)
+                            generator.manual_seed(chunk.node.seedGenerator.value)
+
+                        # Perform inference
+                        pipe_out: MarigoldDepthOutput = pipe(
+                            input_image,
+                            denoising_steps=denoise_steps,
+                            ensemble_size=ensemble_size,
+                            processing_res=processing_res,
+                            match_input_res=match_input_res,
+                            batch_size=0,
+                            color_map="Spectral",
+                            show_progress_bar=False,
+                            resample_method=resample_method,
+                            generator=generator,
+                        )
+
+                        image_stem = Path(chunk_image_paths[idx]).stem
+                        image_stem = str(image_stem)
+
+                        depth_pred: np.ndarray = pipe_out.depth_np
+                        depth_colored: Image.Image = pipe_out.depth_colored
+
+                        depth_vis_file_name = "depth_vis_" + image_stem + ".png"
+                        depth_vis_file_path = str(output_dir_path / depth_vis_file_name)
+                        depth_file_name = "depth_" + image_stem + chunk.node.outputFormat.value
+                        depth_file_path = str(output_dir_path / depth_file_name)
+
+                        if chunk.node.outputFormat.value == '.npy':
+                            # Save as npy
+                            np.save(depth_file_path, depth_pred)
+                        else:
+                            depth_to_save = depth_pred[:,:,np.newaxis].copy()
+                            image.writeImage(depth_file_path, depth_to_save, h_ori, w_ori, orientation, pixelAspectRatio)
+
+                        if chunk.node.saveVisuImages.value:
+                            # Save Colorize
+                            depth_colored.save(depth_vis_file_path)
+
+            if chunk.node.computeNormals.value:
+                from marigold import MarigoldNormalsPipeline, MarigoldNormalsOutput
+
+                pipe: MarigoldNormalsPipeline = loadPipe.loadPipe("normals")
+                denoise_steps = chunk.node.denoisingStep.value if chunk.node.denoisingStep.value > 0 else 4
+                ensemble_size = chunk.node.ensembleSize.value if chunk.node.ensembleSize.value > 0 else 10
+
+                chunk.logger.info('Normals processing parameters:')
+                chunk.logger.info(f'    Processing Resolution = {processing_res or pipe.default_processing_resolution}')
+                chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
+                chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
+
+                for idx, path in enumerate(chunk_image_paths):
+                    with torch.no_grad():
+                        input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), applyPAR = True)
+                        input_image = Image.fromarray((255.0*input_image).astype(np.uint8))
+
+                        # Random number generator
+                        if chunk.node.seedGenerator.value < 0:
+                            generator = None
+                        else:
+                            generator = torch.Generator(device=device)
+                            generator.manual_seed(chunk.node.seedGenerator.value)
+
+                        # Perform inference
+                        pipe_out: MarigoldNormalsOutput = pipe(
+                            input_image,
+                            denoising_steps=denoise_steps,
+                            ensemble_size=ensemble_size,
+                            processing_res=processing_res,
+                            match_input_res=match_input_res,
+                            batch_size=0,
+                            show_progress_bar=False,
+                            resample_method=resample_method,
+                            generator=generator,
+                        )
+
+                        image_stem = Path(chunk_image_paths[idx]).stem
+                        image_stem = str(image_stem)
+
+                        normals_pred: np.ndarray = pipe_out.normals_np
+                        normals_colored: Image.Image = pipe_out.normals_img
+
+                        normals_vis_file_name = "normals_vis_" + image_stem + ".png"
+                        normals_vis_file_path = str(output_dir_path / normals_vis_file_name)
+                        normals_file_name = "normals_" + image_stem + chunk.node.outputFormat.value
+                        normals_file_path = str(output_dir_path / normals_file_name)
+
+                        if chunk.node.outputFormat.value == '.npy':
+                            # Save as npy
+                            np.save(normals_file_path, normals_pred)
+                        else:
+                            normals_to_save = np.transpose(normals_pred, (1, 2, 0)).copy()
+                            image.writeImage(normals_file_path, normals_to_save, h_ori, w_ori, orientation, pixelAspectRatio)
+
+                        if chunk.node.saveVisuImages.value:
+                            # Save Colorize
+                            normals_colored.save(normals_vis_file_path)
+
+            if chunk.node.computeAppearance.value:
+                from marigold import MarigoldIIDPipeline, MarigoldIIDOutput
+
+                pipe: MarigoldIIDPipeline = loadPipe.loadPipe("appearance")
+                denoise_steps = chunk.node.denoisingStep.value if chunk.node.denoisingStep.value > 0 else 4
+                ensemble_size = chunk.node.ensembleSize.value if chunk.node.ensembleSize.value > 0 else 1
+
+                chunk.logger.info('Appearance processing parameters:')
+                chunk.logger.info(f'    Processing Resolution = {processing_res or pipe.default_processing_resolution}')
+                chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
+                chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
+
+                for idx, path in enumerate(chunk_image_paths):
+                    with torch.no_grad():
+                        input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), applyPAR = True)
+                        input_image = Image.fromarray((255.0*input_image).astype(np.uint8))
+
+                        # Random number generator
+                        if chunk.node.seedGenerator.value < 0:
+                            generator = None
+                        else:
+                            generator = torch.Generator(device=device)
+                            generator.manual_seed(chunk.node.seedGenerator.value)
+
+                        # Perform inference
+                        pipe_out: MarigoldIIDOutput = pipe(
+                            input_image,
+                            denoising_steps=denoise_steps,
+                            ensemble_size=ensemble_size,
+                            processing_res=processing_res,
+                            match_input_res=match_input_res,
+                            batch_size=0,
+                            show_progress_bar=False,
+                            resample_method=resample_method,
+                            generator=generator,
+                        )
+
+                        image_stem = Path(chunk_image_paths[idx]).stem
+                        image_stem = str(image_stem)
+
+                        for pred_name in pipe.target_names: #["albedo", "material"]
+                            pred: np.ndarray = np.moveaxis(pipe_out[pred_name].array, 0, -1).copy()
+                            pred_file_name = pred_name + "_appearance_" + image_stem + chunk.node.outputFormat.value
+                            pred_file_path = str(output_dir_path / pred_file_name)
+                            if chunk.node.outputFormat.value == '.npy':
+                                # Save as npy
+                                np.save(pred_file_path, pred)
+                            else:
+                                image.writeImage(pred_file_path, pred, h_ori, w_ori, orientation, pixelAspectRatio)
+
+            if chunk.node.computeLighting.value:
+                from marigold import MarigoldIIDPipeline, MarigoldIIDOutput
+
+                pipe: MarigoldIIDPipeline = loadPipe.loadPipe("lighting")
+                denoise_steps = chunk.node.denoisingStep.value if chunk.node.denoisingStep.value > 0 else 4
+                ensemble_size = chunk.node.denoisingStep.value if chunk.node.denoisingStep.value > 0 else 1
+
+                chunk.logger.info('Lighting processing parameters:')
+                chunk.logger.info(f'    Processing Resolution = {processing_res or pipe.default_processing_resolution}')
+                chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
+                chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
+
+                for idx, path in enumerate(chunk_image_paths):
+                    with torch.no_grad():
+                        input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), applyPAR = True)
+                        input_image = Image.fromarray((255.0*input_image).astype(np.uint8))
+
+                        # Random number generator
+                        if chunk.node.seedGenerator.value < 0:
+                            generator = None
+                        else:
+                            generator = torch.Generator(device=device)
+                            generator.manual_seed(chunk.node.seedGenerator.value)
+
+                        # Perform inference
+                        pipe_out: MarigoldIIDOutput = pipe(
+                            input_image,
+                            denoising_steps=denoise_steps,
+                            ensemble_size=ensemble_size,
+                            processing_res=processing_res,
+                            match_input_res=match_input_res,
+                            batch_size=0,
+                            show_progress_bar=False,
+                            resample_method=resample_method,
+                            generator=generator,
+                        )
+
+                        image_stem = Path(chunk_image_paths[idx]).stem
+                        image_stem = str(image_stem)
+
+                        for pred_name in pipe.target_names: #["albedo", "shading", "residual"]
+                            pred: np.ndarray = np.moveaxis(pipe_out[pred_name].array, 0, -1).copy()
+                            pred_file_name = pred_name + "_lighting_" + image_stem + chunk.node.outputFormat.value
+                            pred_file_path = str(output_dir_path / pred_file_name)
+                            if chunk.node.outputFormat.value == '.npy':
+                                # Save as npy
+                                np.save(pred_file_path, pred)
+                            else:
+                                image.writeImage(pred_file_path, pred, h_ori, w_ori, orientation, pixelAspectRatio)
+
+            chunk.logger.info('Marigold end')
+        finally:
+            chunk.logManager.end()
+
+def get_image_paths_list(input_path, extension):
+    from pyalicevision import sfmData
+    from pyalicevision import sfmDataIO
+    from pathlib import Path
+    import itertools
+
+    include_suffixes = [extension.lower(), extension.upper()]
+    image_paths = []
+
+    if Path(input_path).is_dir():
+        image_paths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+    elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+        if Path(input_path).exists():
+            dataAV = sfmData.SfMData()
+            if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):
+                views = dataAV.getViews()
+                for id, v in views.items():
+                    image_paths.append(Path(v.getImage().getImagePath()))
+            image_paths.sort()
+    else:
+        raise ValueError(f"Input path '{input_path}' is not a valid path (folder or sfmData file).")
+    return image_paths


### PR DESCRIPTION
This PR adds a node implementing the "[Marigold](https://github.com/prs-eth/Marigold)" pipelines dedicated to depth, normal, appearance and lighting features.

About depth, the pipeline dedicated to [depth completion](https://github.com/prs-eth/Marigold-DC/tree/main) is also available.

The image module has been updated to support enhanced image loading. Output color space and image clipping can now be managed in the "loadImage" function.

