### PR TITLE
Insert model info in metadata

### DIFF
--- a/img_proc/image.py
+++ b/img_proc/image.py
@@ -86,7 +86,7 @@ def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = T
 
     return (oiio_image, h, w, pixelAspectRatio, orientation)
 
-def writeImage(imagePath: str, image: np.ndarray, h_tgt: int, w_tgt: int, orientation: int = 1, pixelAspectRatio: float = 1.0) -> None:
+def writeImage(imagePath: str, image: np.ndarray, h_tgt: int, w_tgt: int, orientation: int = 1, pixelAspectRatio: float = 1.0, metadata = {}) -> None:
     if orientation > 1:
         image = apply_orientation(image, orientation, reverse=True)
         if orientation > 4:
@@ -127,6 +127,11 @@ def writeImage(imagePath: str, image: np.ndarray, h_tgt: int, w_tgt: int, orient
         optWrite.toColorSpace(avimg.EImageColorSpace_SRGB)
     compression = "zips" if Path(imagePath).suffix.lower() == ".exr" else ""
     oiio_params = avimg.oiioParams(orientation, pixelAspectRatio, compression)
+
+    for name, value in metadata.items():
+        if isinstance(name, str) and isinstance(value, str) and name != "" and value != "":
+            oiio_params.add(name, value)
+
     avimg.writeImage(imagePath, av_image, optWrite, oiio_params.get())
 
 def loadSequence(sequencePath: str, incolorspace: str = 'acescg', start: int = 0, stop: int = -1, verbose = False):

--- a/img_proc/image.py
+++ b/img_proc/image.py
@@ -86,7 +86,9 @@ def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = T
 
     return (oiio_image, h, w, pixelAspectRatio, orientation)
 
-def writeImage(imagePath: str, image: np.ndarray, h_tgt: int, w_tgt: int, orientation: int = 1, pixelAspectRatio: float = 1.0, metadata = {}) -> None:
+def writeImage(imagePath: str, image: np.ndarray, h_tgt: int, w_tgt: int, orientation: int = 1, pixelAspectRatio: float = 1.0, metadata=None) -> None:
+    if metadata is None:
+        metadata = {}
     if orientation > 1:
         image = apply_orientation(image, orientation, reverse=True)
         if orientation > 4:

--- a/meshroom/imageIntrinsicsEstimation/Marigold.py
+++ b/meshroom/imageIntrinsicsEstimation/Marigold.py
@@ -337,6 +337,10 @@ class Marigold(desc.Node):
                 chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
                 chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
 
+                metadata_deep_model = {}
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-Depth"
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                 for idx, path in enumerate(chunk_image_paths):
                     input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx][0]), applyPAR = True)
                     input_image = Image.fromarray((255.0*input_image).astype(np.uint8))
@@ -403,10 +407,6 @@ class Marigold(desc.Node):
 
                         depth_file_path = str(output_dir_path / depth_file_name)
 
-                        metadata_deep_model = {}
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-Depth"
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
-
                         if chunk.node.outputFormat.value == '.npy' or (input_depth is not None and str(Path(input_depth[1]).suffix) == '.npy'):
                             # Save as npy
                             np.save(depth_file_path, depth_pred)
@@ -442,6 +442,10 @@ class Marigold(desc.Node):
                 chunk.logger.info(f'    Processing Resolution = {processing_res or pipe.default_processing_resolution}')
                 chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
                 chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
+
+                metadata_deep_model = {}
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-Normal"
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
 
                 for idx, path in enumerate(chunk_image_paths):
                     with torch.no_grad():
@@ -479,10 +483,6 @@ class Marigold(desc.Node):
                         normals_file_name = "normals_" + image_stem + chunk.node.outputFormat.value
                         normals_file_path = str(output_dir_path / normals_file_name)
 
-                        metadata_deep_model = {}
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-Normal"
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
-
                         if chunk.node.outputFormat.value == '.npy':
                             # Save as npy
                             np.save(normals_file_path, normals_pred)
@@ -506,6 +506,10 @@ class Marigold(desc.Node):
                 chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
                 chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
 
+                metadata_deep_model = {}
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-IID-Appearance"
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                 for idx, path in enumerate(chunk_image_paths):
                     with torch.no_grad():
                         input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx][0]), applyPAR = True)
@@ -533,10 +537,6 @@ class Marigold(desc.Node):
 
                         image_stem = Path(chunk_image_paths[idx][0]).stem
                         image_stem = str(image_stem)
-
-                        metadata_deep_model = {}
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-IID-Appearance"
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
 
                         for pred_name in pipe.target_names: #["albedo", "material"]
                             pred: np.ndarray = np.moveaxis(pipe_out[pred_name].array, 0, -1).copy()
@@ -560,6 +560,10 @@ class Marigold(desc.Node):
                 chunk.logger.info(f'    Denoising Step(s) = {denoise_steps}')
                 chunk.logger.info(f'    Ensemble Size = {ensemble_size}')
 
+                metadata_deep_model = {}
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-IID-Lighting"
+                metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                 for idx, path in enumerate(chunk_image_paths):
                     with torch.no_grad():
                         input_image, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx][0]), applyPAR = True)
@@ -587,10 +591,6 @@ class Marigold(desc.Node):
 
                         image_stem = Path(chunk_image_paths[idx][0]).stem
                         image_stem = str(image_stem)
-
-                        metadata_deep_model = {}
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-IID-Lighting"
-                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
 
                         for pred_name in pipe.target_names: #["albedo", "shading", "residual"]
                             pred: np.ndarray = np.moveaxis(pipe_out[pred_name].array, 0, -1).copy()

--- a/meshroom/imageIntrinsicsEstimation/Marigold.py
+++ b/meshroom/imageIntrinsicsEstimation/Marigold.py
@@ -403,12 +403,16 @@ class Marigold(desc.Node):
 
                         depth_file_path = str(output_dir_path / depth_file_name)
 
+                        metadata_deep_model = {}
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-Depth"
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                         if chunk.node.outputFormat.value == '.npy' or (input_depth is not None and str(Path(input_depth[1]).suffix) == '.npy'):
                             # Save as npy
                             np.save(depth_file_path, depth_pred)
                         else:
                             depth_to_save = depth_pred[:,:,np.newaxis].copy()
-                            image.writeImage(depth_file_path, depth_to_save, h_ori, w_ori, orientation, pixelAspectRatio)
+                            image.writeImage(depth_file_path, depth_to_save, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
                             if input_depth is not None:
                                 minDepth = depth_pred.min()
                                 maxDepth = depth_pred.max()
@@ -419,7 +423,7 @@ class Marigold(desc.Node):
                             # Save Colorize
                             depth_vis_file_name = "depth_vis_" + image_stem + ".png"
                             depth_vis_file_path = str(output_dir_path / depth_vis_file_name)
-                            image.writeImage(depth_vis_file_path, depth_colored, h_ori, w_ori, orientation, pixelAspectRatio)
+                            image.writeImage(depth_vis_file_path, depth_colored, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
                             if input_depth is not None:
 
@@ -475,16 +479,20 @@ class Marigold(desc.Node):
                         normals_file_name = "normals_" + image_stem + chunk.node.outputFormat.value
                         normals_file_path = str(output_dir_path / normals_file_name)
 
+                        metadata_deep_model = {}
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-Normal"
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                         if chunk.node.outputFormat.value == '.npy':
                             # Save as npy
                             np.save(normals_file_path, normals_pred)
                         else:
                             normals_to_save = np.transpose(normals_pred, (1, 2, 0)).copy()
-                            image.writeImage(normals_file_path, normals_to_save, h_ori, w_ori, orientation, pixelAspectRatio)
+                            image.writeImage(normals_file_path, normals_to_save, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
                         if chunk.node.saveVisuImages.value:
                             # Save Colorize
-                            image.writeImage(normals_vis_file_path, normals_colored, h_ori, w_ori, orientation, pixelAspectRatio)
+                            image.writeImage(normals_vis_file_path, normals_colored, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
             if chunk.node.computeAppearance.value:
                 from marigold import MarigoldIIDPipeline, MarigoldIIDOutput
@@ -526,6 +534,10 @@ class Marigold(desc.Node):
                         image_stem = Path(chunk_image_paths[idx][0]).stem
                         image_stem = str(image_stem)
 
+                        metadata_deep_model = {}
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-IID-Appearance"
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                         for pred_name in pipe.target_names: #["albedo", "material"]
                             pred: np.ndarray = np.moveaxis(pipe_out[pred_name].array, 0, -1).copy()
                             pred_file_name = pred_name + "_appearance_" + image_stem + chunk.node.outputFormat.value
@@ -534,7 +546,7 @@ class Marigold(desc.Node):
                                 # Save as npy
                                 np.save(pred_file_path, pred)
                             else:
-                                image.writeImage(pred_file_path, pred, h_ori, w_ori, orientation, pixelAspectRatio)
+                                image.writeImage(pred_file_path, pred, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
             if chunk.node.computeLighting.value:
                 from marigold import MarigoldIIDPipeline, MarigoldIIDOutput
@@ -576,6 +588,10 @@ class Marigold(desc.Node):
                         image_stem = Path(chunk_image_paths[idx][0]).stem
                         image_stem = str(image_stem)
 
+                        metadata_deep_model = {}
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "Marigold-IID-Lighting"
+                        metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "1.1"
+
                         for pred_name in pipe.target_names: #["albedo", "shading", "residual"]
                             pred: np.ndarray = np.moveaxis(pipe_out[pred_name].array, 0, -1).copy()
                             pred_file_name = pred_name + "_lighting_" + image_stem + chunk.node.outputFormat.value
@@ -584,7 +600,7 @@ class Marigold(desc.Node):
                                 # Save as npy
                                 np.save(pred_file_path, pred)
                             else:
-                                image.writeImage(pred_file_path, pred, h_ori, w_ori, orientation, pixelAspectRatio)
+                                image.writeImage(pred_file_path, pred, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
             chunk.logger.info('Marigold end')
         finally:

--- a/meshroom/imageIntrinsicsEstimation/MoGe.py
+++ b/meshroom/imageIntrinsicsEstimation/MoGe.py
@@ -293,6 +293,10 @@ class MoGe(desc.Node):
 
             fov_x_ =  None if chunk.node.automaticFOVEstimation.value else chunk.node.horizontalFov.value
 
+            metadata_deep_model = {}
+            metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "MoGe-2-vitl-normal"
+            metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "2025.03.06"
+
             for idx, path in enumerate(chunk_image_paths):
                 with torch.no_grad():
                     img, h_ori, w_ori, pixelAspectRatio, orientation = image.loadImage(str(chunk_image_paths[idx]), applyPAR = True)
@@ -328,34 +332,26 @@ class MoGe(desc.Node):
                     mask_file_name = "mask_" + image_stem + ".exr"
                     mask_file_path = str(outputDirPath / mask_file_name)
 
-                    metadata_deep_model = {}
-                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "MoGe"
-                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "2025.03.06"
                     if chunk.node.outputDepth.value:
                         depth_to_write = depth[:,:,np.newaxis]
-                        image.writeImage(depth_file_path, depth_to_write, h_ori, w_ori, orientation, pixelAspectRatio)
+                        image.writeImage(depth_file_path, depth_to_write, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
                     if chunk.node.outputNormals.value:
                         normals_to_write = normals.astype(np.float32).copy()
                         normals_to_write = normals_to_write * np.array([1, -1, -1], dtype=np.float32)
-                        image.writeImage(normals_file_path, normals_to_write, h_ori, w_ori, orientation, pixelAspectRatio)
+                        image.writeImage(normals_file_path, normals_to_write, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
                     if chunk.node.outputDepth.value and chunk.node.saveVisuImages.value:
                         colored_depth = colorize_depth(depth).copy()
-                        image.writeImage(vis_file_path, colored_depth, h_ori, w_ori, orientation, pixelAspectRatio)
+                        image.writeImage(vis_file_path, colored_depth, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
                     if chunk.node.outputNormals.value and chunk.node.saveVisuImages.value:
                         colored_normals = colorize_normal(normals).copy()
-                        image.writeImage(vis_normal_file_path, colored_normals, h_ori, w_ori, orientation, pixelAspectRatio)
+                        image.writeImage(vis_normal_file_path, colored_normals, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
                     if chunk.node.outputPoints.value:
                         points_to_write = points.copy()
-                        image.writeImage(points_file_path, points_to_write, h_ori, w_ori, orientation, pixelAspectRatio)
+                        image.writeImage(points_file_path, points_to_write, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
                     if chunk.node.outputMask.value:
                         mask_to_write = mask.astype(np.float32).copy()
                         mask_to_write = mask_to_write[:,:,np.newaxis]
-                        image.writeImage(mask_file_path, mask_to_write, h_ori, w_ori, orientation, pixelAspectRatio)
-
-                    image.writeImage(depth_file_path, 1/depth_to_write, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
-                    image.writeImage(normals_file_path, normals, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
-                    image.writeImage(vis_file_path, colored_depth, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
-                    image.writeImage(vis_normal_file_path, colored_normals, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
+                        image.writeImage(mask_file_path, mask_to_write, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
                     fov_x, fov_y = utils3d.numpy.intrinsics_to_fov(intrinsics)
 

--- a/meshroom/imageIntrinsicsEstimation/MoGe.py
+++ b/meshroom/imageIntrinsicsEstimation/MoGe.py
@@ -328,6 +328,9 @@ class MoGe(desc.Node):
                     mask_file_name = "mask_" + image_stem + ".exr"
                     mask_file_path = str(outputDirPath / mask_file_name)
 
+                    metadata_deep_model = {}
+                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "MoGe"
+                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "2025.03.06"
                     if chunk.node.outputDepth.value:
                         depth_to_write = depth[:,:,np.newaxis]
                         image.writeImage(depth_file_path, depth_to_write, h_ori, w_ori, orientation, pixelAspectRatio)
@@ -348,6 +351,11 @@ class MoGe(desc.Node):
                         mask_to_write = mask.astype(np.float32).copy()
                         mask_to_write = mask_to_write[:,:,np.newaxis]
                         image.writeImage(mask_file_path, mask_to_write, h_ori, w_ori, orientation, pixelAspectRatio)
+
+                    image.writeImage(depth_file_path, 1/depth_to_write, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
+                    image.writeImage(normals_file_path, normals, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
+                    image.writeImage(vis_file_path, colored_depth, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
+                    image.writeImage(vis_normal_file_path, colored_normals, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
 
                     fov_x, fov_y = utils3d.numpy.intrinsics_to_fov(intrinsics)
 

--- a/meshroom/imageIntrinsicsEstimation/StableNormal.py
+++ b/meshroom/imageIntrinsicsEstimation/StableNormal.py
@@ -168,6 +168,10 @@ class StableNormal(desc.Node):
             # computation
             chunk.logger.info(f'Starting computation on chunk {chunk.range.iteration + 1}/{chunk.range.fullSize // chunk.range.blockSize + int(chunk.range.fullSize != chunk.range.blockSize)}...')
 
+            metadata_deep_model = {}
+            metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "stableNormal"
+            metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "0.1"
+
             for idx, path in enumerate(chunk_image_paths):
                 #if idx > 0:
                 with torch.no_grad():
@@ -196,10 +200,6 @@ class StableNormal(desc.Node):
 
                     prediction = pipe_out.prediction[0].copy()
                     normalMap = (prediction.clip(-1,1) + 1) / 2
-
-                    metadata_deep_model = {}
-                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "stableNormal"
-                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "2025.08.12"
 
                     outputDirPath = Path(chunk.node.output.value)
                     image_stem = Path(chunk_image_paths[idx]).stem

--- a/meshroom/imageIntrinsicsEstimation/StableNormal.py
+++ b/meshroom/imageIntrinsicsEstimation/StableNormal.py
@@ -197,11 +197,15 @@ class StableNormal(desc.Node):
                     prediction = pipe_out.prediction[0].copy()
                     normalMap = (prediction.clip(-1,1) + 1) / 2
 
+                    metadata_deep_model = {}
+                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelName"] = "stableNormal"
+                    metadata_deep_model["Meshroom:mrImageIntrinsicsDecomposition:DeepModelVersion"] = "2025.08.12"
+
                     outputDirPath = Path(chunk.node.output.value)
                     image_stem = Path(chunk_image_paths[idx]).stem
                     of_file_name = "normal_" + image_stem + ".exr"
 
-                    image.writeImage(str(outputDirPath / of_file_name), normalMap, h_ori, w_ori, orientation, pixelAspectRatio)
+                    image.writeImage(str(outputDirPath / of_file_name), normalMap, h_ori, w_ori, orientation, pixelAspectRatio, metadata_deep_model)
             
             chunk.logger.info('Publish end')
         finally:


### PR DESCRIPTION
This pull request enhances the image writing workflow in several image intrinsics estimation modules by allowing custom metadata to be embedded in output images. The main change is the extension of the `writeImage` function to accept a metadata dictionary, which is then populated with model-specific information (such as model name and version) in each module. This ensures that all generated images carry consistent and informative provenance metadata.

**Core API enhancement:**

* [`img_proc/image.py`] : The `writeImage` function now accepts an optional `metadata` dictionary parameter, and adds valid string key-value pairs from this dictionary to the image's metadata before saving.

**Marigold module improvements:**

* [`meshroom/imageIntrinsicsEstimation/Marigold.py`] : In each processing section (Depth, Normal, IID-Appearance, IID-Lighting), a `metadata_deep_model` dictionary is created with the model name and version, and passed to `writeImage` for all relevant image outputs. This ensures that all outputs are tagged with the correct model provenance.

**MoGe module improvements:**

* [`meshroom/imageIntrinsicsEstimation/MoGe.py`] : Similar to Marigold, a `metadata_deep_model` dictionary with model name and version is created and passed to all `writeImage` calls, ensuring consistent metadata tagging for all output images.

**StableNormal module improvements:**

* [`meshroom/imageIntrinsicsEstimation/StableNormal.py`] : Adds model name and version to a `metadata_deep_model` dictionary and passes it to `writeImage` for normal map outputs.