### PR TITLE
Update node version and remove useless group=""

### DIFF
--- a/meshroom/compareDepthAndNormalModels.mg
+++ b/meshroom/compareDepthAndNormalModels.mg
@@ -5,12 +5,12 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "DepthAnythingV2": "1.0",
-            "DepthPro": "1.0",
-            "Marigold": "1.0",
-            "MoGe": "1.0",
-            "PixelPerfectDepth": "1.0",
-            "StableNormal": "1.0"
+            "DepthAnythingV2": "2.0",
+            "DepthPro": "2.0",
+            "Marigold": "2.0",
+            "MoGe": "2.0",
+            "PixelPerfectDepth": "2.0",
+            "StableNormal": "2.0"
         },
         "template": true
     },

--- a/meshroom/imageDepthComputation.mg
+++ b/meshroom/imageDepthComputation.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "Marigold": "1.0"
+            "Marigold": "2.0"
         },
         "template": true
     },

--- a/meshroom/imageIntrinsicsEstimation/DepthAnythingV2.py
+++ b/meshroom/imageIntrinsicsEstimation/DepthAnythingV2.py
@@ -111,7 +111,6 @@ class DepthAnythingV2(desc.Node):
             description="Output depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.outputDepth.value,
         ),
         desc.File(
@@ -120,7 +119,6 @@ class DepthAnythingV2(desc.Node):
             description="Output colored depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_vis_<FILESTEM>.png",
-            group="",
             enabled=lambda node: node.outputDepth.value and node.saveVisuImages.value,
         ),
     ]

--- a/meshroom/imageIntrinsicsEstimation/DepthAnythingV3.py
+++ b/meshroom/imageIntrinsicsEstimation/DepthAnythingV3.py
@@ -91,7 +91,6 @@ class DepthAnythingV3(desc.Node):
             description="Output depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.outputDepth.value,
         ),
         desc.File(
@@ -100,7 +99,6 @@ class DepthAnythingV3(desc.Node):
             description="Output colored depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_vis_<FILESTEM>.png",
-            group="",
             enabled=lambda node: node.outputDepth.value and node.saveVisuImages.value,
         ),
     ]

--- a/meshroom/imageIntrinsicsEstimation/Marigold.py
+++ b/meshroom/imageIntrinsicsEstimation/Marigold.py
@@ -154,7 +154,6 @@ class Marigold(desc.Node):
             description="Output normal map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/normals_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeNormals.value
         ),
         desc.File(
@@ -163,7 +162,6 @@ class Marigold(desc.Node):
             description="Colored output normal map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/normals_vis_<FILESTEM>.png",
-            group="",
             enabled=lambda node: node.computeNormals.value and node.saveVisuImages.value
         ),
         desc.File(
@@ -172,7 +170,6 @@ class Marigold(desc.Node):
             description="Output depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeDepth.value
         ),
         desc.File(
@@ -181,7 +178,6 @@ class Marigold(desc.Node):
             description="Colored output depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_vis_<FILESTEM>.png",
-            group="",
             enabled=lambda node: node.computeDepth.value and node.saveVisuImages.value
         ),
         desc.File(
@@ -190,7 +186,6 @@ class Marigold(desc.Node):
             description="Colored input sparse depth map",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/input_depth_vis_<FILESTEM>.png",
-            group="",
             enabled=lambda node: node.computeDepth.value and node.saveVisuImages.value and node.inputDepthMaps.isLink
         ),
         desc.File(
@@ -199,7 +194,6 @@ class Marigold(desc.Node):
             description="Output albedo extrated from appearance model",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/albedo_appearance_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeAppearance.value and node.outputFormat.value == ".exr"
         ),
         desc.File(
@@ -208,7 +202,6 @@ class Marigold(desc.Node):
             description="Output albedo extrated from lighting model",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/albedo_lighting_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeLighting.value and node.outputFormat.value == ".exr"
         ),
         desc.File(
@@ -217,7 +210,6 @@ class Marigold(desc.Node):
             description="Output material extrated from appearance model",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/material_appearance_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeAppearance.value and node.outputFormat.value == ".exr"
         ),
         desc.File(
@@ -226,7 +218,6 @@ class Marigold(desc.Node):
             description="Output shading extrated from lighting model",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/shading_lighting_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeLighting.value and node.outputFormat.value == ".exr"
         ),
         desc.File(
@@ -235,7 +226,6 @@ class Marigold(desc.Node):
             description="Output residual extrated from lighting model",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/residual_lighting_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.computeLighting.value and node.outputFormat.value == ".exr"
         ),
     ]

--- a/meshroom/imageIntrinsicsEstimation/PixelPerfectDepth.py
+++ b/meshroom/imageIntrinsicsEstimation/PixelPerfectDepth.py
@@ -81,7 +81,6 @@ class PixelPerfectDepth(desc.Node):
             description="Generated depth maps.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_<FILESTEM>.exr",
-            group="",
             enabled=lambda node: node.outputDepth.value,
         ),
         desc.File(
@@ -90,7 +89,6 @@ class PixelPerfectDepth(desc.Node):
             description="Generated colored depth maps.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/depth_vis_<FILESTEM>.png",
-            group="",
             enabled=lambda node: node.outputDepth.value and node.saveVisuImages.value,
         ),
     ]

--- a/meshroom/imageIntrinsicsEstimation/StableNormal.py
+++ b/meshroom/imageIntrinsicsEstimation/StableNormal.py
@@ -76,7 +76,6 @@ class StableNormal(desc.Node):
             description="Output normal maps",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/normal_<FILESTEM>.exr",
-            group="",
         )
     ]
 

--- a/meshroom/imageNormalComputation.mg
+++ b/meshroom/imageNormalComputation.mg
@@ -5,7 +5,7 @@
         "nodesVersions": {
             "CameraInit": "12.0",
             "CopyFiles": "1.3",
-            "MoGe": "1.0"
+            "MoGe": "2.0"
         },
         "template": true
     },


### PR DESCRIPTION
This pull request updates several Meshroom pipeline files and node implementations to use the latest versions of depth and normal estimation models, and removes the unused `group` parameter from file output descriptors in multiple node classes. These changes ensure that the pipelines reference updated algorithms and simplify node definitions by eliminating redundant code.
